### PR TITLE
nabu: use vintf_fragment_modules instead of vintf_fragments

### DIFF
--- a/aidl/hwcontrol/rust_impl/Android.bp
+++ b/aidl/hwcontrol/rust_impl/Android.bp
@@ -3,9 +3,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
+vintf_fragment {
+    name: "custom.hardware.hwcontrol.xml",
+    src: "custom.hardware.hwcontrol.xml",
+}
 rust_binary {
     name: "custom.hardware.hwcontrol-service",
-    vintf_fragments: ["custom.hardware.hwcontrol.xml"],
+    vintf_fragment_modules: ["custom.hardware.hwcontrol.xml"],
     init_rc: ["custom.hardware.hwcontrol.rc"],
     srcs: [
         "src/main.rs",


### PR DESCRIPTION
<img width="1901" height="65" alt="图片" src="https://github.com/user-attachments/assets/3b526a08-4ca9-4792-86ab-01d90f32ad7b" />
